### PR TITLE
update readme.org to include link to steps.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,4 +3,4 @@ Develop a program for storing and retrieving chord events from a database
 
 ** Commentary
 
-Gee, it sure would be nice to be told how to make sense of this project!
+[see the steps.org file](https://github.com/cicerojones/chords/blob/master/doc/steps.org) for a detailed sequence of steps


### PR DESCRIPTION
Instead of making you have to navigate to the one helpful org-file, let's link to it from the readme.org
